### PR TITLE
spike refactor of logstashbridge stable API

### DIFF
--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/StableBridgeAPI.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/StableBridgeAPI.java
@@ -19,43 +19,51 @@ import java.util.stream.Collectors;
  * upon by the "Elastic Integration Filter Plugin" for Logstash and their external shapes must not change
  * without coordination with the maintainers of that project.
  *
- * @param <T> the actual type of the Elasticsearch API being mirrored
+ * @param <INTERNAL> the actual type of the Elasticsearch API being mirrored
  */
-public interface StableBridgeAPI<T> {
-    T unwrap();
+public interface StableBridgeAPI<INTERNAL> {
+    INTERNAL toInternal();
 
-    static <T> T unwrapNullable(final StableBridgeAPI<T> nullableStableBridgeAPI) {
+    static <T> T toInternalNullable(final StableBridgeAPI<T> nullableStableBridgeAPI) {
         if (Objects.isNull(nullableStableBridgeAPI)) {
             return null;
         }
-        return nullableStableBridgeAPI.unwrap();
+        return nullableStableBridgeAPI.toInternal();
     }
 
-    static <K, T> Map<K, T> unwrap(final Map<K, ? extends StableBridgeAPI<T>> bridgeMap) {
-        return bridgeMap.entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().unwrap()));
+    static <K, T> Map<K, T> toInternal(final Map<K, ? extends StableBridgeAPI<T>> bridgeMap) {
+        return bridgeMap.entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().toInternal()));
     }
 
-    static <K, T, B extends StableBridgeAPI<T>> Map<K, B> wrap(final Map<K, T> rawMap, final Function<T, B> wrapFunction) {
-        return rawMap.entrySet().stream().collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> wrapFunction.apply(e.getValue())));
+    static <K, T, B extends StableBridgeAPI<T>> Map<K, B> fromInternal(final Map<K, T> rawMap, final Function<T, B> externalizor) {
+        return rawMap.entrySet()
+                     .stream()
+                     .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> externalizor.apply(e.getValue())));
     }
 
-    static <T, B extends StableBridgeAPI<T>> B wrap(final T delegate, final Function<T, B> wrapFunction) {
+    static <T, B extends StableBridgeAPI<T>> B fromInternal(final T delegate, final Function<T, B> externalizor) {
         if (Objects.isNull(delegate)) {
             return null;
         }
-        return wrapFunction.apply(delegate);
+        return externalizor.apply(delegate);
     }
 
-    abstract class Proxy<T> implements StableBridgeAPI<T> {
-        protected final T delegate;
+    /**
+     * An {@code ProxyInternal<INTERNAL>} is an implementation of {@code StableBridgeAPI<INTERNAL>} that
+     * proxies calls to a delegate that is an actual {@code INTERNAL}.
+     *
+     * @param <INTERNAL>
+     */
+    abstract class ProxyInternal<INTERNAL> implements StableBridgeAPI<INTERNAL> {
+        protected final INTERNAL internalDelegate;
 
-        protected Proxy(final T delegate) {
-            this.delegate = delegate;
+        protected ProxyInternal(final INTERNAL internalDelegate) {
+            this.internalDelegate = internalDelegate;
         }
 
         @Override
-        public T unwrap() {
-            return delegate;
+        public INTERNAL toInternal() {
+            return internalDelegate;
         }
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/common/SettingsBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/common/SettingsBridge.java
@@ -11,14 +11,17 @@ package org.elasticsearch.logstashbridge.common;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.logstashbridge.StableBridgeAPI;
 
-public class SettingsBridge extends StableBridgeAPI.Proxy<Settings> {
+/**
+ * An external bridge for {@link Settings}
+ */
+public class SettingsBridge extends StableBridgeAPI.ProxyInternal<Settings> {
 
-    public static SettingsBridge wrap(final Settings delegate) {
+    public static SettingsBridge fromInternal(final Settings delegate) {
         return new SettingsBridge(delegate);
     }
 
     public static Builder builder() {
-        return Builder.wrap(Settings.builder());
+        return Builder.fromInternal(Settings.builder());
     }
 
     public SettingsBridge(final Settings delegate) {
@@ -26,12 +29,15 @@ public class SettingsBridge extends StableBridgeAPI.Proxy<Settings> {
     }
 
     @Override
-    public Settings unwrap() {
-        return this.delegate;
+    public Settings toInternal() {
+        return this.internalDelegate;
     }
 
-    public static class Builder extends StableBridgeAPI.Proxy<Settings.Builder> {
-        static Builder wrap(final Settings.Builder delegate) {
+    /**
+     * An external bridge for {@link Settings.Builder} that proxies calls to a real {@link Settings.Builder}
+     */
+    public static class Builder extends StableBridgeAPI.ProxyInternal<Settings.Builder> {
+        static Builder fromInternal(final Settings.Builder delegate) {
             return new Builder(delegate);
         }
 
@@ -40,12 +46,12 @@ public class SettingsBridge extends StableBridgeAPI.Proxy<Settings> {
         }
 
         public Builder put(final String key, final String value) {
-            this.delegate.put(key, value);
+            this.internalDelegate.put(key, value);
             return this;
         }
 
         public SettingsBridge build() {
-            return new SettingsBridge(this.delegate.build());
+            return new SettingsBridge(this.internalDelegate.build());
         }
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/core/IOUtilsBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/core/IOUtilsBridge.java
@@ -12,6 +12,9 @@ import org.elasticsearch.core.IOUtils;
 
 import java.io.Closeable;
 
+/**
+ * An external bridge for {@link IOUtils}
+ */
 public class IOUtilsBridge {
     public static void closeWhileHandlingException(final Iterable<? extends Closeable> objects) {
         IOUtils.closeWhileHandlingException(objects);

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/env/EnvironmentBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/env/EnvironmentBridge.java
@@ -14,13 +14,16 @@ import org.elasticsearch.logstashbridge.common.SettingsBridge;
 
 import java.nio.file.Path;
 
-public class EnvironmentBridge extends StableBridgeAPI.Proxy<Environment> {
-    public static EnvironmentBridge wrap(final Environment delegate) {
+/**
+ * An external bridge for {@link Environment}
+ */
+public class EnvironmentBridge extends StableBridgeAPI.ProxyInternal<Environment> {
+    public static EnvironmentBridge fromInternal(final Environment delegate) {
         return new EnvironmentBridge(delegate);
     }
 
     public EnvironmentBridge(final SettingsBridge settingsBridge, final Path configPath) {
-        this(new Environment(settingsBridge.unwrap(), configPath));
+        this(new Environment(settingsBridge.toInternal(), configPath));
     }
 
     private EnvironmentBridge(final Environment delegate) {
@@ -28,7 +31,7 @@ public class EnvironmentBridge extends StableBridgeAPI.Proxy<Environment> {
     }
 
     @Override
-    public Environment unwrap() {
-        return this.delegate;
+    public Environment toInternal() {
+        return this.internalDelegate;
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/ConfigurationUtilsBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/ConfigurationUtilsBridge.java
@@ -14,6 +14,9 @@ import org.elasticsearch.logstashbridge.script.TemplateScriptBridge;
 
 import java.util.Map;
 
+/**
+ * An external bridge for {@link ConfigurationUtils}
+ */
 public class ConfigurationUtilsBridge {
     public static TemplateScriptBridge.Factory compileTemplate(
         final String processorType,
@@ -23,7 +26,7 @@ public class ConfigurationUtilsBridge {
         final ScriptServiceBridge scriptServiceBridge
     ) {
         return new TemplateScriptBridge.Factory(
-            ConfigurationUtils.compileTemplate(processorType, processorTag, propertyName, propertyValue, scriptServiceBridge.unwrap())
+            ConfigurationUtils.compileTemplate(processorType, processorTag, propertyName, propertyValue, scriptServiceBridge.toInternal())
         );
     }
 

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/IngestDocumentBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/IngestDocumentBridge.java
@@ -18,7 +18,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 
-public class IngestDocumentBridge extends StableBridgeAPI.Proxy<IngestDocument> {
+/**
+ * An external bridge for {@link IngestDocument} that proxies calls through a real {@link IngestDocument}
+ */
+public class IngestDocumentBridge extends StableBridgeAPI.ProxyInternal<IngestDocument> {
 
     public static final class Constants {
         public static final String METADATA_VERSION_FIELD_NAME = IngestDocument.Metadata.VERSION.getFieldName();
@@ -26,7 +29,7 @@ public class IngestDocumentBridge extends StableBridgeAPI.Proxy<IngestDocument> 
         private Constants() {}
     }
 
-    public static IngestDocumentBridge wrap(final IngestDocument ingestDocument) {
+    public static IngestDocumentBridge fromInternalNullable(final IngestDocument ingestDocument) {
         if (ingestDocument == null) {
             return null;
         }
@@ -42,54 +45,57 @@ public class IngestDocumentBridge extends StableBridgeAPI.Proxy<IngestDocument> 
     }
 
     public MetadataBridge getMetadata() {
-        return new MetadataBridge(delegate.getMetadata());
+        return new MetadataBridge(internalDelegate.getMetadata());
     }
 
     public Map<String, Object> getSource() {
-        return delegate.getSource();
+        return internalDelegate.getSource();
     }
 
     public boolean updateIndexHistory(final String index) {
-        return delegate.updateIndexHistory(index);
+        return internalDelegate.updateIndexHistory(index);
     }
 
     public Set<String> getIndexHistory() {
-        return Set.copyOf(delegate.getIndexHistory());
+        return Set.copyOf(internalDelegate.getIndexHistory());
     }
 
     public boolean isReroute() {
-        return LogstashInternalBridge.isReroute(delegate);
+        return LogstashInternalBridge.isReroute(internalDelegate);
     }
 
     public void resetReroute() {
-        LogstashInternalBridge.resetReroute(delegate);
+        LogstashInternalBridge.resetReroute(internalDelegate);
     }
 
     public Map<String, Object> getIngestMetadata() {
-        return delegate.getIngestMetadata();
+        return internalDelegate.getIngestMetadata();
     }
 
     public <T> T getFieldValue(final String fieldName, final Class<T> type) {
-        return delegate.getFieldValue(fieldName, type);
+        return internalDelegate.getFieldValue(fieldName, type);
     }
 
     public <T> T getFieldValue(final String fieldName, final Class<T> type, final boolean ignoreMissing) {
-        return delegate.getFieldValue(fieldName, type, ignoreMissing);
+        return internalDelegate.getFieldValue(fieldName, type, ignoreMissing);
     }
 
     public String renderTemplate(final TemplateScriptBridge.Factory templateScriptFactory) {
-        return delegate.renderTemplate(templateScriptFactory.unwrap());
+        return internalDelegate.renderTemplate(templateScriptFactory.toInternal());
     }
 
     public void setFieldValue(final String path, final Object value) {
-        delegate.setFieldValue(path, value);
+        internalDelegate.setFieldValue(path, value);
     }
 
     public void removeField(final String path) {
-        delegate.removeField(path);
+        internalDelegate.removeField(path);
     }
 
     public void executePipeline(final PipelineBridge pipelineBridge, final BiConsumer<IngestDocumentBridge, Exception> handler) {
-        this.delegate.executePipeline(pipelineBridge.unwrap(), (unwrapped, e) -> handler.accept(IngestDocumentBridge.wrap(unwrapped), e));
+        this.internalDelegate.executePipeline(pipelineBridge.toInternal(),
+                                              (ingestDocument, e) -> {
+                                                  handler.accept(IngestDocumentBridge.fromInternalNullable(ingestDocument), e);
+                                              });
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineBridge.java
@@ -16,8 +16,11 @@ import org.elasticsearch.logstashbridge.script.ScriptServiceBridge;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
-public class PipelineBridge extends StableBridgeAPI.Proxy<Pipeline> {
-    public static PipelineBridge wrap(final Pipeline pipeline) {
+/**
+ * An external bridge for {@link Pipeline}
+ */
+public class PipelineBridge extends StableBridgeAPI.ProxyInternal<Pipeline> {
+    public static PipelineBridge fromInternal(final Pipeline pipeline) {
         return new PipelineBridge(pipeline);
     }
 
@@ -28,12 +31,12 @@ public class PipelineBridge extends StableBridgeAPI.Proxy<Pipeline> {
         Map<String, ProcessorBridge.Factory> processorFactories,
         ScriptServiceBridge scriptServiceBridge
     ) throws Exception {
-        return wrap(
+        return fromInternal(
             Pipeline.create(
                 id,
                 config,
-                StableBridgeAPI.unwrap(processorFactories),
-                StableBridgeAPI.unwrapNullable(scriptServiceBridge),
+                StableBridgeAPI.toInternal(processorFactories),
+                StableBridgeAPI.toInternalNullable(scriptServiceBridge),
                 null
             )
         );
@@ -44,13 +47,13 @@ public class PipelineBridge extends StableBridgeAPI.Proxy<Pipeline> {
     }
 
     public String getId() {
-        return delegate.getId();
+        return internalDelegate.getId();
     }
 
     public void execute(final IngestDocumentBridge ingestDocumentBridge, final BiConsumer<IngestDocumentBridge, Exception> handler) {
-        this.delegate.execute(
-            StableBridgeAPI.unwrapNullable(ingestDocumentBridge),
-            (unwrapped, e) -> handler.accept(IngestDocumentBridge.wrap(unwrapped), e)
+        this.internalDelegate.execute(
+            StableBridgeAPI.toInternalNullable(ingestDocumentBridge),
+            (ingestDocument, e) -> handler.accept(IngestDocumentBridge.fromInternalNullable(ingestDocument), e)
         );
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineConfigurationBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/PipelineConfigurationBridge.java
@@ -15,7 +15,10 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.util.Map;
 
-public class PipelineConfigurationBridge extends StableBridgeAPI.Proxy<PipelineConfiguration> {
+/**
+ * An external bridge for {@link PipelineConfiguration}
+ */
+public class PipelineConfigurationBridge extends StableBridgeAPI.ProxyInternal<PipelineConfiguration> {
     public PipelineConfigurationBridge(final PipelineConfiguration delegate) {
         super(delegate);
     }
@@ -25,25 +28,25 @@ public class PipelineConfigurationBridge extends StableBridgeAPI.Proxy<PipelineC
     }
 
     public String getId() {
-        return delegate.getId();
+        return internalDelegate.getId();
     }
 
     public Map<String, Object> getConfig() {
-        return delegate.getConfig();
+        return internalDelegate.getConfig();
     }
 
     public Map<String, Object> getConfig(final boolean unmodifiable) {
-        return delegate.getConfig(unmodifiable);
+        return internalDelegate.getConfig(unmodifiable);
     }
 
     @Override
     public int hashCode() {
-        return delegate.hashCode();
+        return internalDelegate.hashCode();
     }
 
     @Override
     public String toString() {
-        return delegate.toString();
+        return internalDelegate.toString();
     }
 
     @Override
@@ -51,7 +54,7 @@ public class PipelineConfigurationBridge extends StableBridgeAPI.Proxy<PipelineC
         if (this == obj) {
             return true;
         } else if (obj instanceof PipelineConfigurationBridge other) {
-            return delegate.equals(other.delegate);
+            return internalDelegate.equals(other.internalDelegate);
         } else {
             return false;
         }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/ProcessorBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/ingest/ProcessorBridge.java
@@ -22,8 +22,14 @@ import org.elasticsearch.logstashbridge.threadpool.ThreadPoolBridge;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+/**
+ * An external bridge for {@link Processor}
+ */
 public interface ProcessorBridge extends StableBridgeAPI<Processor> {
 
+    /**
+     * An external bridge for processor-related constants
+     */
     final class Constants {
         private Constants() {}
 
@@ -72,86 +78,104 @@ public interface ProcessorBridge extends StableBridgeAPI<Processor> {
 
     void execute(IngestDocumentBridge ingestDocumentBridge, BiConsumer<IngestDocumentBridge, Exception> handler);
 
-    static ProcessorBridge wrap(final Processor delegate) {
-        if (delegate instanceof InverseWrapped inverseWrapped) {
-            return inverseWrapped.delegate;
+    static ProcessorBridge fromInternal(final Processor internalProcessor) {
+        if (internalProcessor instanceof AbstractExternal.ProxyExternal externalProxy) {
+            return externalProxy.getProcessorBridge();
         }
-        return new Wrapped(delegate);
+        return new ProxyInternal(internalProcessor);
     }
 
-    class Wrapped extends StableBridgeAPI.Proxy<Processor> implements ProcessorBridge {
-        public Wrapped(final Processor delegate) {
+    /**
+     * The {@code ProcessorBridge.AbstractExternal} is an abstract base class for implementing
+     * the {@link ProcessorBridge} externally to the Elasticsearch code-base. It takes care of
+     * the details of maintaining a singular internal-form implementation of {@link Processor}
+     * that proxies calls through the external implementation.
+     */
+    abstract class AbstractExternal implements ProcessorBridge {
+        private ProxyExternal internalProcessor;
+
+        public Processor toInternal() {
+            if (internalProcessor == null) {
+                internalProcessor = new ProxyExternal();
+            }
+            return internalProcessor;
+        }
+
+        private class ProxyExternal implements Processor {
+
+            @Override
+            public String getType() {
+                return AbstractExternal.this.getType();
+            }
+
+            @Override
+            public String getTag() {
+                return AbstractExternal.this.getTag();
+            }
+
+            @Override
+            public String getDescription() {
+                return AbstractExternal.this.getDescription();
+            }
+
+            @Override
+            public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+                AbstractExternal.this.execute(IngestDocumentBridge.fromInternalNullable(ingestDocument),
+                                              (idb, e) -> handler.accept(idb.toInternal(), e));
+            }
+
+            @Override
+            public boolean isAsync() {
+                return AbstractExternal.this.isAsync();
+            }
+
+            private AbstractExternal getProcessorBridge() {
+                return AbstractExternal.this;
+            }
+        }
+    }
+
+    /**
+     * An implementation of {@link ProcessorBridge} that proxies to an internal {@link Processor}
+     */
+    class ProxyInternal extends StableBridgeAPI.ProxyInternal<Processor> implements ProcessorBridge {
+        public ProxyInternal(final Processor delegate) {
             super(delegate);
         }
 
         @Override
         public String getType() {
-            return unwrap().getType();
+            return toInternal().getType();
         }
 
         @Override
         public String getTag() {
-            return unwrap().getTag();
+            return toInternal().getTag();
         }
 
         @Override
         public String getDescription() {
-            return unwrap().getDescription();
+            return toInternal().getDescription();
         }
 
         @Override
         public boolean isAsync() {
-            return unwrap().isAsync();
+            return toInternal().isAsync();
         }
 
         @Override
         public void execute(final IngestDocumentBridge ingestDocumentBridge, final BiConsumer<IngestDocumentBridge, Exception> handler) {
-            delegate.execute(
-                StableBridgeAPI.unwrapNullable(ingestDocumentBridge),
-                (id, e) -> handler.accept(IngestDocumentBridge.wrap(id), e)
+            internalDelegate.execute(
+                StableBridgeAPI.toInternalNullable(ingestDocumentBridge),
+                (id, e) -> handler.accept(IngestDocumentBridge.fromInternalNullable(id), e)
             );
         }
     }
 
-    @Override
-    default Processor unwrap() {
-        return new InverseWrapped(this);
-    }
-
-    class InverseWrapped implements Processor {
-        private final ProcessorBridge delegate;
-
-        public InverseWrapped(final ProcessorBridge delegate) {
-            this.delegate = delegate;
-        }
-
-        @Override
-        public String getType() {
-            return delegate.getType();
-        }
-
-        @Override
-        public String getTag() {
-            return delegate.getTag();
-        }
-
-        @Override
-        public String getDescription() {
-            return delegate.getDescription();
-        }
-
-        @Override
-        public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
-            this.delegate.execute(IngestDocumentBridge.wrap(ingestDocument), (idb, e) -> handler.accept(idb.unwrap(), e));
-        }
-
-        @Override
-        public boolean isAsync() {
-            return delegate.isAsync();
-        }
-    }
-
-    class Parameters extends StableBridgeAPI.Proxy<Processor.Parameters> {
+    /**
+     * An external bridge for {@link Processor.Parameters}
+     */
+    class Parameters extends StableBridgeAPI.ProxyInternal<Processor.Parameters> {
 
         public Parameters(
             final EnvironmentBridge environmentBridge,
@@ -160,17 +184,17 @@ public interface ProcessorBridge extends StableBridgeAPI<Processor> {
         ) {
             this(
                 new Processor.Parameters(
-                    environmentBridge.unwrap(),
-                    scriptServiceBridge.unwrap(),
+                    environmentBridge.toInternal(),
+                    scriptServiceBridge.toInternal(),
                     null,
-                    threadPoolBridge.unwrap().getThreadContext(),
-                    threadPoolBridge.unwrap()::relativeTimeInMillis,
-                    (delay, command) -> threadPoolBridge.unwrap()
-                        .schedule(command, TimeValue.timeValueMillis(delay), threadPoolBridge.unwrap().generic()),
+                    threadPoolBridge.toInternal().getThreadContext(),
+                    threadPoolBridge.toInternal()::relativeTimeInMillis,
+                    (delay, command) -> threadPoolBridge.toInternal()
+                        .schedule(command, TimeValue.timeValueMillis(delay), threadPoolBridge.toInternal().generic()),
                     null,
                     null,
-                    threadPoolBridge.unwrap().generic()::execute,
-                    IngestService.createGrokThreadWatchdog(environmentBridge.unwrap(), threadPoolBridge.unwrap())
+                    threadPoolBridge.toInternal().generic()::execute,
+                    IngestService.createGrokThreadWatchdog(environmentBridge.toInternal(), threadPoolBridge.toInternal())
                 )
             );
         }
@@ -180,11 +204,14 @@ public interface ProcessorBridge extends StableBridgeAPI<Processor> {
         }
 
         @Override
-        public Processor.Parameters unwrap() {
-            return this.delegate;
+        public Processor.Parameters toInternal() {
+            return this.internalDelegate;
         }
     }
 
+    /**
+     * An external bridge for {@link Processor.Factory}
+     */
     interface Factory extends StableBridgeAPI<Processor.Factory> {
         ProcessorBridge create(
             Map<String, ProcessorBridge.Factory> registry,
@@ -193,23 +220,26 @@ public interface ProcessorBridge extends StableBridgeAPI<Processor> {
             Map<String, Object> config
         ) throws Exception;
 
-        static Factory wrap(final Processor.Factory delegate) {
-            return new Wrapped(delegate);
+        static Factory fromInternal(final Processor.Factory delegate) {
+            return new ProxyInternal(delegate);
         }
 
         @Override
-        default Processor.Factory unwrap() {
+        default Processor.Factory toInternal() {
             final Factory stableAPIFactory = this;
             return (registry, tag, description, config, projectId) -> stableAPIFactory.create(
-                StableBridgeAPI.wrap(registry, Factory::wrap),
+                StableBridgeAPI.fromInternal(registry, Factory::fromInternal),
                 tag,
                 description,
                 config
-            ).unwrap();
+            ).toInternal();
         }
 
-        class Wrapped extends StableBridgeAPI.Proxy<Processor.Factory> implements Factory {
-            private Wrapped(final Processor.Factory delegate) {
+        /**
+         * An implementation of {@link ProcessorBridge.Factory} that proxies to an internal {@link Processor.Factory}
+         */
+        class ProxyInternal extends StableBridgeAPI.ProxyInternal<Processor.Factory> implements Factory {
+            private ProxyInternal(final Processor.Factory delegate) {
                 super(delegate);
             }
 
@@ -221,14 +251,14 @@ public interface ProcessorBridge extends StableBridgeAPI<Processor> {
                 final String description,
                 final Map<String, Object> config
             ) throws Exception {
-                return ProcessorBridge.wrap(
-                    this.delegate.create(StableBridgeAPI.unwrap(registry), processorTag, description, config, ProjectId.DEFAULT)
+                return ProcessorBridge.fromInternal(
+                    this.internalDelegate.create(StableBridgeAPI.toInternal(registry), processorTag, description, config, ProjectId.DEFAULT)
                 );
             }
 
             @Override
-            public Processor.Factory unwrap() {
-                return this.delegate;
+            public Processor.Factory toInternal() {
+                return this.internalDelegate;
             }
         }
     }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/plugins/IngestCommonPluginBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/plugins/IngestCommonPluginBridge.java
@@ -14,6 +14,9 @@ import org.elasticsearch.logstashbridge.ingest.ProcessorBridge;
 
 import java.util.Map;
 
+/**
+ * An external bridge for {@link IngestCommonPlugin}
+ */
 public class IngestCommonPluginBridge implements IngestPluginBridge {
 
     private final IngestCommonPlugin delegate;
@@ -24,6 +27,6 @@ public class IngestCommonPluginBridge implements IngestPluginBridge {
 
     @Override
     public Map<String, ProcessorBridge.Factory> getProcessors(final ProcessorBridge.Parameters parameters) {
-        return StableBridgeAPI.wrap(this.delegate.getProcessors(parameters.unwrap()), ProcessorBridge.Factory::wrap);
+        return StableBridgeAPI.fromInternal(this.delegate.getProcessors(parameters.toInternal()), ProcessorBridge.Factory::fromInternal);
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/plugins/IngestPluginBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/plugins/IngestPluginBridge.java
@@ -16,31 +16,38 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
 
+/**
+ * An external bridge for {@link IngestPlugin}
+ */
 public interface IngestPluginBridge {
     Map<String, ProcessorBridge.Factory> getProcessors(ProcessorBridge.Parameters parameters);
 
-    static Wrapped wrap(final IngestPlugin delegate) {
-        return new Wrapped(delegate);
+    static ProxyInternal fromInternal(final IngestPlugin delegate) {
+        return new ProxyInternal(delegate);
     }
 
-    class Wrapped extends StableBridgeAPI.Proxy<IngestPlugin> implements IngestPluginBridge, Closeable {
+    /**
+     * An implementation of {@link IngestPluginBridge} that proxies calls to an internal {@link IngestPlugin}
+     */
+    class ProxyInternal extends StableBridgeAPI.ProxyInternal<IngestPlugin> implements IngestPluginBridge, Closeable {
 
-        private Wrapped(final IngestPlugin delegate) {
+        private ProxyInternal(final IngestPlugin delegate) {
             super(delegate);
         }
 
         public Map<String, ProcessorBridge.Factory> getProcessors(final ProcessorBridge.Parameters parameters) {
-            return StableBridgeAPI.wrap(this.delegate.getProcessors(parameters.unwrap()), ProcessorBridge.Factory::wrap);
+            return StableBridgeAPI.fromInternal(this.internalDelegate.getProcessors(parameters.toInternal()),
+                                                ProcessorBridge.Factory::fromInternal);
         }
 
         @Override
-        public IngestPlugin unwrap() {
-            return this.delegate;
+        public IngestPlugin toInternal() {
+            return this.internalDelegate;
         }
 
         @Override
         public void close() throws IOException {
-            if (this.delegate instanceof Closeable closeableDelegate) {
+            if (this.internalDelegate instanceof Closeable closeableDelegate) {
                 closeableDelegate.close();
             }
         }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/plugins/IngestUserAgentPluginBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/plugins/IngestUserAgentPluginBridge.java
@@ -14,6 +14,9 @@ import org.elasticsearch.logstashbridge.ingest.ProcessorBridge;
 
 import java.util.Map;
 
+/**
+ * An external bridge for {@link IngestUserAgentPlugin}
+ */
 public class IngestUserAgentPluginBridge implements IngestPluginBridge {
 
     private final IngestUserAgentPlugin delegate;
@@ -23,6 +26,6 @@ public class IngestUserAgentPluginBridge implements IngestPluginBridge {
     }
 
     public Map<String, ProcessorBridge.Factory> getProcessors(final ProcessorBridge.Parameters parameters) {
-        return StableBridgeAPI.wrap(this.delegate.getProcessors(parameters.unwrap()), ProcessorBridge.Factory::wrap);
+        return StableBridgeAPI.fromInternal(this.delegate.getProcessors(parameters.toInternal()), ProcessorBridge.Factory::fromInternal);
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/plugins/RedactPluginBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/plugins/RedactPluginBridge.java
@@ -14,15 +14,18 @@ import org.elasticsearch.xpack.redact.RedactProcessor;
 
 import java.util.Map;
 
+/**
+ * An external bridge for {@link org.elasticsearch.xpack.redact.RedactPlugin}
+ */
 public class RedactPluginBridge implements IngestPluginBridge {
     @Override
     public Map<String, ProcessorBridge.Factory> getProcessors(ProcessorBridge.Parameters parameters) {
         // Provide a TRIAL license state to the redact processor
-        final XPackLicenseState trialLicenseState = new XPackLicenseState(parameters.unwrap().relativeTimeSupplier);
+        final XPackLicenseState trialLicenseState = new XPackLicenseState(parameters.toInternal().relativeTimeSupplier);
 
         return Map.of(
             RedactProcessor.TYPE,
-            ProcessorBridge.Factory.wrap(new RedactProcessor.Factory(trialLicenseState, parameters.unwrap().matcherWatchdog))
+            ProcessorBridge.Factory.fromInternal(new RedactProcessor.Factory(trialLicenseState, parameters.toInternal().matcherWatchdog))
         );
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/script/MetadataBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/script/MetadataBridge.java
@@ -13,52 +13,55 @@ import org.elasticsearch.script.Metadata;
 
 import java.time.ZonedDateTime;
 
-public class MetadataBridge extends StableBridgeAPI.Proxy<Metadata> {
+/**
+ * An external bridge for {@link Metadata}
+ */
+public class MetadataBridge extends StableBridgeAPI.ProxyInternal<Metadata> {
     public MetadataBridge(final Metadata delegate) {
         super(delegate);
     }
 
     public String getIndex() {
-        return delegate.getIndex();
+        return internalDelegate.getIndex();
     }
 
     public void setIndex(final String index) {
-        delegate.setIndex(index);
+        internalDelegate.setIndex(index);
     }
 
     public String getId() {
-        return delegate.getId();
+        return internalDelegate.getId();
     }
 
     public void setId(final String id) {
-        delegate.setId(id);
+        internalDelegate.setId(id);
     }
 
     public long getVersion() {
-        return delegate.getVersion();
+        return internalDelegate.getVersion();
     }
 
     public void setVersion(final long version) {
-        delegate.setVersion(version);
+        internalDelegate.setVersion(version);
     }
 
     public String getVersionType() {
-        return delegate.getVersionType();
+        return internalDelegate.getVersionType();
     }
 
     public void setVersionType(final String versionType) {
-        delegate.setVersionType(versionType);
+        internalDelegate.setVersionType(versionType);
     }
 
     public String getRouting() {
-        return delegate.getRouting();
+        return internalDelegate.getRouting();
     }
 
     public void setRouting(final String routing) {
-        delegate.setRouting(routing);
+        internalDelegate.setRouting(routing);
     }
 
     public ZonedDateTime getNow() {
-        return delegate.getNow();
+        return internalDelegate.getNow();
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/script/ScriptServiceBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/script/ScriptServiceBridge.java
@@ -36,13 +36,16 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.LongSupplier;
 
-public class ScriptServiceBridge extends StableBridgeAPI.Proxy<ScriptService> implements Closeable {
-    public ScriptServiceBridge wrap(final ScriptService delegate) {
+/**
+ * An external bridge for {@link ScriptService}
+ */
+public class ScriptServiceBridge extends StableBridgeAPI.ProxyInternal<ScriptService> implements Closeable {
+    public ScriptServiceBridge fromInternal(final ScriptService delegate) {
         return new ScriptServiceBridge(delegate);
     }
 
     public ScriptServiceBridge(final SettingsBridge settingsBridge, final LongSupplier timeProvider) throws IOException {
-        super(getScriptService(settingsBridge.unwrap(), timeProvider));
+        super(getScriptService(settingsBridge.toInternal(), timeProvider));
     }
 
     public ScriptServiceBridge(ScriptService delegate) {
@@ -103,6 +106,6 @@ public class ScriptServiceBridge extends StableBridgeAPI.Proxy<ScriptService> im
 
     @Override
     public void close() throws IOException {
-        this.delegate.close();
+        this.internalDelegate.close();
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/script/TemplateScriptBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/script/TemplateScriptBridge.java
@@ -11,9 +11,16 @@ package org.elasticsearch.logstashbridge.script;
 import org.elasticsearch.logstashbridge.StableBridgeAPI;
 import org.elasticsearch.script.TemplateScript;
 
+/**
+ * An external bridge for {@link TemplateScript}
+ */
 public class TemplateScriptBridge {
-    public static class Factory extends StableBridgeAPI.Proxy<TemplateScript.Factory> {
-        public static Factory wrap(final TemplateScript.Factory delegate) {
+
+    /**
+     * An external bridge for {@link TemplateScript.Factory}
+     */
+    public static class Factory extends StableBridgeAPI.ProxyInternal<TemplateScript.Factory> {
+        public static Factory fromInternal(final TemplateScript.Factory delegate) {
             return new Factory(delegate);
         }
 
@@ -22,8 +29,8 @@ public class TemplateScriptBridge {
         }
 
         @Override
-        public TemplateScript.Factory unwrap() {
-            return this.delegate;
+        public TemplateScript.Factory toInternal() {
+            return this.internalDelegate;
         }
     }
 }

--- a/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/threadpool/ThreadPoolBridge.java
+++ b/libs/logstash-bridge/src/main/java/org/elasticsearch/logstashbridge/threadpool/ThreadPoolBridge.java
@@ -16,10 +16,13 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.concurrent.TimeUnit;
 
-public class ThreadPoolBridge extends StableBridgeAPI.Proxy<ThreadPool> {
+/**
+ * An external bridge for {@link ThreadPool}
+ */
+public class ThreadPoolBridge extends StableBridgeAPI.ProxyInternal<ThreadPool> {
 
     public ThreadPoolBridge(final SettingsBridge settingsBridge) {
-        this(new ThreadPool(settingsBridge.unwrap(), MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders()));
+        this(new ThreadPool(settingsBridge.toInternal(), MeterRegistry.NOOP, new DefaultBuiltInExecutorBuilders()));
     }
 
     public ThreadPoolBridge(final ThreadPool delegate) {
@@ -27,14 +30,14 @@ public class ThreadPoolBridge extends StableBridgeAPI.Proxy<ThreadPool> {
     }
 
     public static boolean terminate(final ThreadPoolBridge pool, final long timeout, final TimeUnit timeUnit) {
-        return ThreadPool.terminate(pool.unwrap(), timeout, timeUnit);
+        return ThreadPool.terminate(pool.toInternal(), timeout, timeUnit);
     }
 
     public long relativeTimeInMillis() {
-        return delegate.relativeTimeInMillis();
+        return internalDelegate.relativeTimeInMillis();
     }
 
     public long absoluteTimeInMillis() {
-        return delegate.absoluteTimeInMillis();
+        return internalDelegate.absoluteTimeInMillis();
     }
 }


### PR DESCRIPTION
This is a spike that does a few things on top of [your adoption spike](https://github.com/elastic/elasticsearch/pull/131486) in response to [the LS-filter PR](https://github.com/elastic/logstash-filter-elastic_integration/pull/336/files). I can go back and make smaller commits if it helps.


# Internal & External vs Unwrap & Wrap

It is easy to get lost as to what wrap and unwrap mean, especially since we are actually _implementing_ some of these bridge interfaces over in the LS-filer.

Uses "internal" and "external" terminology throughout. 

   - the type parameter of `StableBridgeAPI<T>` becomes `StableBridgeAPI<INTERNAL>` to make it clear that the type we mirroring is the elasticsearch-internal type
   - methods that consume an elasticsearch-internal type to produce a bridged type change from `wrap` to `fromInternal`
   - methods that consume a bridged type to produce an elasticsearch-internal type change from `unwrap` to `toInternal`
   - the `StableBridgeAPI.Proxy<T>` class—which implements `StableBridgeAPI<T>` becomes `StableBridgeAPI.ProxyInternal<INTERNAL>` to make it clearer that we are proxying an elasticsearch-internal object

To accommodate this change in your [your stable bridge adoption spike](https://github.com/elastic/logstash-filter-elastic_integration/pull/336/files): 
 - `/s/unwrap/toInternal/g`
 - `/s/wrap/fromInternal/g` 

## Abstract Base Class of ProcessorBridge for external implementations

Adds an abstract base class for external implementations called `ProcessorBridge.AbstractExternal`
   - handles the `toInternal` by providing an `ProxyExternal` that satisfies the elasticsearch-internal `Processor` by proxying through to the external implementation of the `PipelineBridge`
   - ensures that we don't nest proxies-of-proxies -- the `ProcessorBridge.fromInternal(Processor)` intercepts these external-proxies and returns their wrapped external bridge implementation directly instead of double-wrapping them

To accommodate this: [`PipelineProcessor`](https://github.com/elastic/logstash-filter-elastic_integration/pull/336/files#diff-4617d99b78081be83f0299d5117cebb6b946ca6d5e84c89c50f534be50495e17) will need to extend `ProcessorBridge.AbstractExternal` instead of implementing `ProcessorBridge`.

## Better commentary for classes and interfaces.

Resolved a lot of code-style warnings by describing the function of classes